### PR TITLE
Comment absolute path:  setwd()

### DIFF
--- a/server.R
+++ b/server.R
@@ -10,7 +10,7 @@ shinyServer(
   function(input, output, session){
     
     # setwd
-    setwd("C:/Users/akruse/Documents/Projekte_Weitere/stadtrad")
+    # setwd("C:/Users/akruse/Documents/Projekte_Weitere/stadtrad")
     
     # load hamburg shape for map
     hhshape <- readOGR(dsn = ".", layer = "HH_ALKIS_Landesgrenze")


### PR DESCRIPTION
Absolute path stops the execution of this repo. In case you'd like to make this repo reproducible.
My guess is you are setting the working directory because this app lives in a server with others.